### PR TITLE
fix: rename job name from lint to status-check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: type-check and lint
 on: [push]
 
 jobs:
-  lint:
+  status-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
- jobの名前を "lint" から、"status-check" に変更 (このjobはstatus-checkに使用されるjobであるため)
- PRを作った時に自分がreviewerに振られるのかをチェック