### PR TITLE
[IndividualPage] scroll to top when moving

### DIFF
--- a/src/pages/IndividualPage/IndividualPage.tsx
+++ b/src/pages/IndividualPage/IndividualPage.tsx
@@ -11,6 +11,7 @@ import { Visited } from 'AppRoot';
 import { LayoutType } from 'constants/Layout';
 import { Coord } from 'constants/MapCoords';
 import { sortWorksByDistance } from 'utils/sortWorks';
+
 interface Params {
   id: string;
 }
@@ -37,7 +38,6 @@ const IndividualPageComponent: React.VFC<RouteComponentProps<Params> & Props> = 
   const history = useHistory();
   const containerRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
-    console.log(worksId);
     containerRef.current?.scrollIntoView({
       behavior: 'smooth',
       block: 'start',


### PR DESCRIPTION
https://github.com/arco0922/iiiex-main2021-works/pull/66#issuecomment-963704913 に対応  
「近くにある作品」を押したときに、作品ページをページ最上部までスクロールさせるようにした．