### PR TITLE
[WorksDetailBottom.tsx] fix: fix link box height to 100%

### DIFF
--- a/src/pages/TopPage/WorksDetailBottom.tsx
+++ b/src/pages/TopPage/WorksDetailBottom.tsx
@@ -139,6 +139,7 @@ const StyledLink = styled(Link)`
   align-items: center;
   justify-content: center;
   width: 100%;
+  height: 100%;
   text-align: center;
   text-decoration: none;
   color: white;


### PR DESCRIPTION
## やったこと
- narrowレイアウトで下に表示されるリンクのクリック範囲が狭いのを修正