### PR TITLE
フルスクリーンから戻った時にスクロールがフリーズするバグの解消

### DIFF
--- a/src/hooks/useFixScroll.ts
+++ b/src/hooks/useFixScroll.ts
@@ -6,6 +6,8 @@ export const isSmoothScrollable = isIOS || isMobile || isTablet;
 export const useFixScroll = (
   scrollContainerRef: React.RefObject<HTMLElement>,
   scrollerRef: React.RefObject<HTMLElement>,
+  //eslint-disable-next-line @typescript-eslint/no-explicit-any
+  deps: any[] = [],
 ): void => {
   React.useEffect(() => {
     if (scrollContainerRef.current === null || scrollerRef.current === null || !isSmoothScrollable) {
@@ -47,15 +49,20 @@ export const useFixScroll = (
       }
     };
 
-    // 最初にページ上部にいるときは、1px下に移動する
-    if (scrollContainer.scrollTop === 0) {
-      scrollContainer.scrollTop = 1;
-    }
-
     scrollContainer.addEventListener('scroll', scrollHandler);
 
     return () => {
       scrollContainer.removeEventListener('scroll', scrollHandler);
     };
   }, [scrollContainerRef, scrollerRef]);
+
+  React.useEffect(() => {
+    if (scrollContainerRef.current === null || scrollerRef.current === null || !isSmoothScrollable) {
+      return;
+    }
+    if (scrollContainerRef.current.scrollTop === 0) {
+      scrollContainerRef.current.scrollTop = 1;
+    }
+    //eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...deps, scrollContainerRef, scrollerRef]);
 };

--- a/src/pages/IndividualPage/IndividualPage.tsx
+++ b/src/pages/IndividualPage/IndividualPage.tsx
@@ -48,10 +48,12 @@ const IndividualPageComponent: React.VFC<RouteComponentProps<Params> & Props> = 
   const worksInfo = React.useMemo(() => worksInfoArr.filter((info) => info.id === worksId)[0], [worksId]);
   const history = useHistory();
 
+  const [isFull, setIsFull] = React.useState<boolean>(false);
+
   const scrollContainerRef = React.useRef<HTMLDivElement>(null);
   const scrollerRef = React.useRef<HTMLDivElement>(null);
 
-  useFixScroll(scrollContainerRef, scrollerRef);
+  useFixScroll(scrollContainerRef, scrollerRef, [isFull, worksId]);
 
   const scrollTopRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
@@ -67,7 +69,7 @@ const IndividualPageComponent: React.VFC<RouteComponentProps<Params> & Props> = 
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [worksInfo]);
-  const [isFull, setIsFull] = React.useState<boolean>(false);
+
   const isNarrowLayout = layout === 'MID' || layout === 'NARROW';
   const iframeWidth = isFull ? '' : isNarrowLayout ? '95vw' : 'min(1000px, max(75vw , 500px))';
   const iframeHeight = isFull


### PR DESCRIPTION
## やったこと
- フルスクリーンから戻った時に、上部にスクロールしようとするとフリーズが発生するバグがあった
- useFixScroll フックに依存配列を渡せるようにして、isFullが変わったタイミングでスクロール位置を一度確認して修正させるようにして解決した