### PR TITLE
本番環境以外では初めにlocalStorageをリセットする

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -47,6 +47,15 @@ export const AppRoot: React.VFC = () => {
   const mapModeIdRef = React.useRef<MapModeId>(1);
 
   React.useEffect(() => {
+    if (isProd) {
+      return;
+    }
+    setMapModeId(1);
+    setVisited(initialVisited);
+    //eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  React.useEffect(() => {
     mapModeIdRef.current = mapModeId;
   }, [mapModeId]);
 


### PR DESCRIPTION
作品やmapModeIdとかが存在しなくなってエラーを吐く可能性があるため本番環境以外ではlocalStorageをリセットするようにした