### PR TITLE
スマホで下の詳細の下にある地図部分がタッチできてしまうバグの修正

### DIFF
--- a/src/components/Sketches/WorksListSketch.tsx
+++ b/src/components/Sketches/WorksListSketch.tsx
@@ -20,6 +20,7 @@ interface Props {
   setSelectId: (id: number) => void;
   initialAnimationStatusRef: React.MutableRefObject<InitialAnimationStatus>;
   setIsShowDetail: (isShowDetail: boolean) => void;
+  isShowDetailRef: React.MutableRefObject<boolean>;
   isShowHamburgerRef: React.MutableRefObject<boolean>;
   layoutRef: React.MutableRefObject<LayoutType>;
   setMapModeId: (mapMode: MapModeId) => void;
@@ -44,6 +45,7 @@ export const WorksListSketch = React.memo<Props>(
     setSelectId,
     initialAnimationStatusRef,
     setIsShowDetail,
+    isShowDetailRef,
     isShowHamburgerRef,
     layoutRef,
     setMapModeId,
@@ -460,7 +462,9 @@ export const WorksListSketch = React.memo<Props>(
     };
 
     const isPointOnCanvas = (p5: p5Types, x: number, y: number) => {
-      return x >= 0 && x <= p5.width && y >= 0 && y <= p5.height;
+      const height =
+        layoutRef.current === 'NARROW' && isShowDetailRef.current ? p5.height - bottomDetailHeight : p5.height;
+      return x >= 0 && x <= p5.width && y >= 0 && y <= height;
     };
 
     const isCursorOnCanvas = (p5: p5Types) => {

--- a/src/pages/TopPage/TopPage.tsx
+++ b/src/pages/TopPage/TopPage.tsx
@@ -43,6 +43,7 @@ export const TopPage: React.VFC<Props> = ({
 }) => {
   const selectIdRef = React.useRef<number>(0);
   const [isShowDetail, setIsShowDetail] = React.useState<boolean>(false);
+  const isShowDetailRef = React.useRef<boolean>(false);
   const [initialAnimationStatus, setInitialAnimationStatus] = React.useState<InitialAnimationStatus>('BEFORE');
   const initialAnimationStatusRef = React.useRef<InitialAnimationStatus>('BEFORE');
   const layoutRef = React.useRef<LayoutType>('WIDE');
@@ -51,6 +52,9 @@ export const TopPage: React.VFC<Props> = ({
   React.useEffect(() => {
     selectIdRef.current = selectId;
   }, [selectId]);
+  React.useEffect(() => {
+    isShowDetailRef.current = isShowDetail;
+  }, [isShowDetail]);
   React.useEffect(() => {
     initialAnimationStatusRef.current = initialAnimationStatus;
   }, [initialAnimationStatus]);
@@ -90,6 +94,7 @@ export const TopPage: React.VFC<Props> = ({
             setSelectId={setSelectId}
             initialAnimationStatusRef={initialAnimationStatusRef}
             setIsShowDetail={setIsShowDetail}
+            isShowDetailRef={isShowDetailRef}
             isShowHamburgerRef={isShowHamburgerRef}
             layoutRef={layoutRef}
             setMapModeId={setMapModeId}


### PR DESCRIPTION
## やったこと
- layoutがNARROWで、詳細が出ている場合は、タップできる範囲をその分制限した。